### PR TITLE
Fix crash in Linux Joystick Implementation

### DIFF
--- a/addons/peripheral.joystick/src/api/linux/JoystickLinux.cpp
+++ b/addons/peripheral.joystick/src/api/linux/JoystickLinux.cpp
@@ -45,6 +45,16 @@ CJoystickLinux::CJoystickLinux(int fd, const std::string& strFilename, CJoystick
 {
 }
 
+bool CJoystickLinux::Initialize(void)
+{
+  m_stateBuffer.buttons.assign(ButtonCount(), JOYSTICK_STATE_BUTTON());
+  m_stateBuffer.hats.assign(HatCount(), JOYSTICK_STATE_HAT());
+  m_stateBuffer.axes.assign(AxisCount(), JOYSTICK_STATE_AXIS());
+
+  return CJoystick::Initialize();
+}
+
+
 void CJoystickLinux::Deinitialize(void)
 {
   close(m_fd);

--- a/addons/peripheral.joystick/src/api/linux/JoystickLinux.cpp
+++ b/addons/peripheral.joystick/src/api/linux/JoystickLinux.cpp
@@ -21,6 +21,7 @@
 #include "JoystickLinux.h"
 #include "JoystickInterfaceLinux.h"
 #include "log/Log.h"
+#include "utils/CommonMacros.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -67,6 +68,9 @@ bool CJoystickLinux::ScanEvents(std::vector<ADDON::PeripheralEvent>& events)
 {
   std::vector<JOYSTICK_STATE_BUTTON>& buttons = m_stateBuffer.buttons;
   std::vector<JOYSTICK_STATE_AXIS>&   axes    = m_stateBuffer.axes;
+
+  ASSERT(buttons.size() == ButtonCount());
+  ASSERT(axes.size() == AxisCount());
 
   ReadEvents(buttons, axes);
 

--- a/addons/peripheral.joystick/src/api/linux/JoystickLinux.h
+++ b/addons/peripheral.joystick/src/api/linux/JoystickLinux.h
@@ -34,6 +34,7 @@ namespace JOYSTICK
     CJoystickLinux(int fd, const std::string& strFilename, CJoystickInterfaceLinux* api);
     virtual ~CJoystickLinux(void) { Deinitialize(); }
 
+    virtual bool Initialize(void);
     virtual void Deinitialize(void);
 
   protected:

--- a/addons/peripheral.joystick/src/api/sdl/JoystickSDL.cpp
+++ b/addons/peripheral.joystick/src/api/sdl/JoystickSDL.cpp
@@ -20,6 +20,7 @@
 
 #include "JoystickSDL.h"
 #include "JoystickInterfaceSDL.h"
+#include "utils/CommonMacros.h"
 
 #define MAX_AXISAMOUNT    32768
 
@@ -31,11 +32,24 @@ CJoystickSDL::CJoystickSDL(SDL_Joystick* pJoystick, CJoystickInterfaceSDL* api)
 {
 }
 
+bool CJoystickSDL::Initialize(void)
+{
+  m_stateBuffer.buttons.assign(ButtonCount(), JOYSTICK_STATE_BUTTON());
+  m_stateBuffer.hats.assign(HatCount(), JOYSTICK_STATE_HAT());
+  m_stateBuffer.axes.assign(AxisCount(), JOYSTICK_STATE_AXIS());
+
+  return CJoystick::Initialize();
+}
+
 bool CJoystickSDL::ScanEvents(std::vector<ADDON::PeripheralEvent>& events)
 {
   std::vector<JOYSTICK_STATE_BUTTON>& buttons = m_stateBuffer.buttons;
   std::vector<JOYSTICK_STATE_HAT>&    hats    = m_stateBuffer.hats;
   std::vector<JOYSTICK_STATE_AXIS>&   axes    = m_stateBuffer.axes;
+
+  ASSERT(buttons.size() == ButtonCount());
+  ASSERT(hats.size() == HatCount());
+  ASSERT(axes.size() == AxisCount());
 
   // Update the state of all opened joysticks
   SDL_JoystickUpdate();

--- a/addons/peripheral.joystick/src/api/sdl/JoystickSDL.h
+++ b/addons/peripheral.joystick/src/api/sdl/JoystickSDL.h
@@ -34,6 +34,7 @@ namespace JOYSTICK
     CJoystickSDL(SDL_Joystick* pJoystick, CJoystickInterfaceSDL* api);
     virtual ~CJoystickSDL(void) { Deinitialize(); }
 
+    bool Initialize(void);
   protected:
     virtual bool ScanEvents(std::vector<ADDON::PeripheralEvent>& events);
 


### PR DESCRIPTION
This fixes a crash on linux.
First commit temporarily fixes the crash when axis/buttons are empty.
Second one adds proper initialize for the JoystickLinux class.