### PR TITLE
fix linux joystick api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 include(CheckIncludeFiles)
 check_include_files(linux/joystick.h HAVE_LINUX_JOYSTICK_H)
 if(HAVE_LINUX_JOYSTICK_H)
-  add_definitions(-DHAS_LINUX_JOYSTICK)
+  add_definitions(-DHAVE_LINUX_JOYSTICK)
   list(APPEND JOYSTICK_SOURCES src/api/linux/JoystickInterfaceLinux.cpp
                                src/api/linux/JoystickLinux.cpp)
 endif()


### PR DESCRIPTION
I always got addon status 6 when trying to load the peripheral.joystick addon.
This happened because the define in the CMakeLists.txt does not match the one used within the code.
Don't know if you want it, but I thought it's maybe a good idea to assert that the interface vector is not empty.